### PR TITLE
Allow falling block check during piston extend to be configurable

### DIFF
--- a/PlotSquared/src/main/java/com/intellectualcrafters/plot/PlotSquared.java
+++ b/PlotSquared/src/main/java/com/intellectualcrafters/plot/PlotSquared.java
@@ -801,6 +801,7 @@ public class PlotSquared {
         options.put("confirmation.delete", Settings.CONFIRM_DELETE);
         options.put("confirmation.unlink", Settings.CONFIRM_UNLINK);
         options.put("protection.tnt-listener.enabled", Settings.TNT_LISTENER);
+        options.put("protection.piston.falling-blocks", Settings.PISTON_FALLING_BLOCK_CHECK);
         options.put("clusters.enabled", Settings.ENABLE_CLUSTERS);
         options.put("clear.fastmode", Settings.ENABLE_CLUSTERS);
         options.put("plotme-alias", Settings.USE_PLOTME_ALIAS);
@@ -846,6 +847,7 @@ public class PlotSquared {
         Settings.CHUNK_PROCESSOR_MAX_ENTITIES= config.getInt("chunk-processor.max-entities");
         
         Settings.TNT_LISTENER = config.getBoolean("protection.tnt-listener.enabled");
+        Settings.PISTON_FALLING_BLOCK_CHECK = config.getBoolean("protection.piston.falling-blocks");
         Settings.PERMISSION_CACHING = config.getBoolean("cache.permissions");
         Settings.CONFIRM_CLEAR = config.getBoolean("confirmation.clear");
         Settings.CONFIRM_DELETE = config.getBoolean("confirmation.delete");

--- a/PlotSquared/src/main/java/com/intellectualcrafters/plot/config/Settings.java
+++ b/PlotSquared/src/main/java/com/intellectualcrafters/plot/config/Settings.java
@@ -56,6 +56,10 @@ public class Settings {
      */
     public static boolean TNT_LISTENER = false;
     /**
+     * Check for falling blocks when pistons extend?
+     */
+    public static boolean PISTON_FALLING_BLOCK_CHECK = true;
+    /**
      * Max auto claiming size
      */
     public static int MAX_AUTO_SIZE = 4;

--- a/PlotSquared/src/main/java/com/intellectualcrafters/plot/listeners/PlayerEvents.java
+++ b/PlotSquared/src/main/java/com/intellectualcrafters/plot/listeners/PlayerEvents.java
@@ -672,6 +672,9 @@ public class PlayerEvents extends com.intellectualcrafters.plot.listeners.PlotLi
                     return;
                 }
             }
+            if (!Settings.PISTON_FALLING_BLOCK_CHECK) {
+                return;
+            }
             org.bukkit.Location lastLoc;
             if (blocks.size() > 0) {
                 lastLoc = blocks.get(blocks.size() - 1).getLocation().add(relative);


### PR DESCRIPTION
The default behavior seems to be interfering with a particular design of TNT cannons which use cobwebs on pistons, with sand caught in the cobwebs as a method of launching large amounts of sand entities at the same time.

~~This patch allows pistons to be extended even if there are falling block entities directly in front of the piston as long as there is also a cobweb. I didn't fully grasp the scope of the original fix so if I am messing something up please let me know.~~ Updated to use a configuration option instead, this seemed like the better choice since there could be other edge cases that have yet to pop up. Cannoning is the primary purpose of my plot server so there's bound to be lots of cases of pistons being used with falling blocks.