### PR TITLE
Get cached PlotPlayer

### DIFF
--- a/PlotSquared/src/main/java/com/intellectualcrafters/plot/util/bukkit/BukkitUtil.java
+++ b/PlotSquared/src/main/java/com/intellectualcrafters/plot/util/bukkit/BukkitUtil.java
@@ -50,6 +50,10 @@ public class BukkitUtil extends BlockManager {
         if (player == lastPlayer) {
             return lastPlotPlayer;
         }
+        final BukkitPlayer plr = (BukkitPlayer) UUIDHandler.players.get(player.getName());
+        if (plr != null && plr.player == player) {
+            return plr;
+        }
         lastPlotPlayer = new BukkitPlayer(player);
         UUIDHandler.players.put(lastPlotPlayer.getName(), lastPlotPlayer);
         lastPlayer = player;


### PR DESCRIPTION
I ran into some issues with PlotPlayer's metadata always being empty. Turns out it was because `BukkitUtil.getPlayer(Player)` was always returning a new PlotPlayer object even for the same player.