### PR TITLE
Add option to allow helpers to WorldEdit

### DIFF
--- a/PlotSquared/src/main/java/com/intellectualcrafters/plot/PlotSquared.java
+++ b/PlotSquared/src/main/java/com/intellectualcrafters/plot/PlotSquared.java
@@ -848,6 +848,7 @@ public class PlotSquared {
         
         // WorldEdit
         options.put("worldedit.require-selection-in-mask", Settings.REQUIRE_SELECTION);
+        options.put("worldedit.enable-for-helpers", Settings.WE_ALLOW_HELPER);
         options.put("worldedit.max-volume", Settings.WE_MAX_VOLUME);
         options.put("worldedit.max-iterations", Settings.WE_MAX_ITERATIONS);
         options.put("worldedit.blacklist", Arrays.asList("cs", ".s", "restore", "snapshot", "delchunks", "listchunks"));
@@ -928,6 +929,7 @@ public class PlotSquared {
         
         // WorldEdit
         Settings.REQUIRE_SELECTION = config.getBoolean("worldedit.require-selection-in-mask");
+        Settings.WE_ALLOW_HELPER = config.getBoolean("worldedit.enable-for-helpers");
         Settings.WE_MAX_VOLUME = config.getLong("worldedit.max-volume");
         Settings.WE_MAX_ITERATIONS = config.getLong("worldedit.max-iterations");
         Settings.WE_BLACKLIST = config.getStringList("worldedit.blacklist");

--- a/PlotSquared/src/main/java/com/intellectualcrafters/plot/config/Settings.java
+++ b/PlotSquared/src/main/java/com/intellectualcrafters/plot/config/Settings.java
@@ -73,6 +73,7 @@ public class Settings {
      * Default worldedit-require-selection-in-mask: false
      */
     public static boolean REQUIRE_SELECTION = true;
+    public static boolean WE_ALLOW_HELPER = false;
     public static long WE_MAX_VOLUME = 500000;
     public static long WE_MAX_ITERATIONS = 1000;
     public static List<String> WE_BLACKLIST = new ArrayList<>();

--- a/PlotSquared/src/main/java/com/intellectualcrafters/plot/listeners/worldedit/WEManager.java
+++ b/PlotSquared/src/main/java/com/intellectualcrafters/plot/listeners/worldedit/WEManager.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import java.util.UUID;
 
 import com.intellectualcrafters.plot.PlotSquared;
+import com.intellectualcrafters.plot.config.Settings;
 import com.intellectualcrafters.plot.object.Location;
 import com.intellectualcrafters.plot.object.Plot;
 import com.intellectualcrafters.plot.object.PlotPlayer;
@@ -27,7 +28,7 @@ public class WEManager {
         UUID uuid = player.getUUID();
         for (Plot plot : PlotSquared.getPlots(player.getLocation().getWorld()).values()) {
             if (!plot.settings.getMerged(0) && !plot.settings.getMerged(3)) {
-                if (plot.isOwner(uuid) || plot.trusted.contains(uuid)) {
+                if (Settings.WE_ALLOW_HELPER ? plot.isAdded(uuid) : (plot.isOwner(uuid) || plot.trusted.contains(uuid))) {
                     Location pos1 = MainUtil.getPlotBottomLoc(plot.world, plot.id).add(1, 0, 1);
                     Location pos2 = MainUtil.getPlotTopLoc(plot.world, plot.id);
                     regions.add(new RegionWrapper(pos1.getX(), pos2.getX(), pos1.getZ(), pos2.getZ()));


### PR DESCRIPTION
There are a couple of differences between helpers and trusted members. Helpers can only build and interact with a plot while the owner is online. Trusted members can do anything, including WorldEdit, at any time.

The distinction between online and offline access is important, and helpers vs trusted makes sense for that, however, it can be desirable to allow WorldEdit access to helpers. This option would allow helpers to use WorldEdit only when the plot owner is online.